### PR TITLE
Fix absolute link to https://www.legal.io

### DIFF
--- a/app/views/static_pages/about.html.slim
+++ b/app/views/static_pages/about.html.slim
@@ -25,7 +25,7 @@
           b Contributors
         p
           | Pieter Gunst - CodeX Fellow / Co-Founder of 
-          a< href="www.legal.io" Legal.io
+          a< href="https://www.legal.io" Legal.io
         p
           |
             Kevin Xu  - Code = Law Participant


### PR DESCRIPTION
Without the protocol `https://`, the link resolves to http://tech.law.stanford.edu/www.legal.io.  Quick fix!