### PR TITLE
Fixing an error with character encoding.  

### DIFF
--- a/app/admin/company.rb
+++ b/app/admin/company.rb
@@ -29,7 +29,7 @@ ActiveAdmin.register Company do
   end
   
   collection_action :export_csv, :method => :get do
-    encoding = Encoding::ISO_8859_1.name
+    encoding = Encoding::UTF_8.name
     csv = CSV.generate( encoding: encoding) do |csv|
       ImportCSVtoCompany.export(csv)
     end

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -16,10 +16,10 @@ ActiveAdmin.register_page "Dashboard" do
        column do
          panel "Export Database" do
            ul do
-             link_to("Download CSV - Companies", "companies/export_csv")
+             link_to("Download CSV - Companies", "admin/companies/export_csv")
            end
            ul do
-             link_to("Upload CSV - Companies", "companies/upload_csv")
+             link_to("Upload CSV - Companies", "admin/companies/upload_csv")
            end
          end
        end


### PR DESCRIPTION
It shows up in production because there must be a record including characters in utf-8 that can't be properly represented in the encoding scheme that was originally selected:

ISO-8859-1

Error:

2016-10-27T23:23:15.585470+00:00 app[web.1]: Completed 500 Internal Server Error in 1022ms (ActiveRecord: 229.7ms)
2016-10-27T23:23:15.586615+00:00 app[web.1]: 
2016-10-27T23:23:15.586617+00:00 app[web.1]: Encoding::UndefinedConversionError (U+2013 from UTF-8 to ISO-8859-1):
2016-10-27T23:23:15.586618+00:00 app[web.1]:   app/models/import_csv_to_company.rb:134:in `block in export'
2016-10-27T23:23:15.586619+00:00 app[web.1]:   app/models/import_csv_to_company.rb:99:in `export'
2016-10-27T23:23:15.586620+00:00 app[web.1]:   app/admin/company.rb:34:in `block (3 levels) in <top (required)>'
2016-10-27T23:23:15.586621+00:00 app[web.1]:   app/admin/company.rb:33:in `block (2 levels) in <top (required)>'